### PR TITLE
Add dispose function for proper disabling of tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ export function Counter() {
   );
 }
 ```
+To disable tracking events, you can call the `dispose` function. This will stop and deinitalize the SDK.
+```js
+import Aptabase from "@aptabase/react-native";
+
+Aptabase.dispose();
+```
 
 **Note for Expo apps:** Events sent during development while running on Expo Go will not have the `App Version` property because native modules are not available in Expo Go. However, when you build your app and run it on a real device, the `App Version` property will be available. Alternatively, you can also set the `appVersion` during the `init` call so that it's also available during development.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { AptabaseOptions } from "./types";
 export { AptabaseProvider, useAptabase } from "./context";
-import { init, trackEvent } from "./track";
-export { init, trackEvent };
+import { init, trackEvent, dispose } from "./track";
+export { init, trackEvent, dispose };
 
-export default { init, trackEvent };
+export default { init, trackEvent, dispose };

--- a/src/track.ts
+++ b/src/track.ts
@@ -16,8 +16,7 @@ export function init(appKey: string, options?: AptabaseOptions) {
   const [ok, msg] = validate(Platform.OS, appKey, options);
   if (!ok) {
     if (_client) {
-      _client.stopPolling();
-      _client = undefined;
+      dispose();
     }
     console.warn(`Aptabase: ${msg}. Tracking will be disabled.`);
     return;
@@ -40,6 +39,18 @@ export function init(appKey: string, options?: AptabaseOptions) {
       _client?.stopPolling();
     }
   });
+}
+
+/**
+ * Dispose the SDK and stop tracking events
+ */
+export function dispose() {
+  if (_client) {
+    _client.stopPolling();
+    _client = undefined;
+  } else {
+    console.warn(`Aptabase: dispose was called but SDK was not initialized.`);
+  }
 }
 
 /**

--- a/src/track.ts
+++ b/src/track.ts
@@ -15,9 +15,6 @@ let _client: AptabaseClient | undefined;
 export function init(appKey: string, options?: AptabaseOptions) {
   const [ok, msg] = validate(Platform.OS, appKey, options);
   if (!ok) {
-    if (_client) {
-      dispose();
-    }
     console.warn(`Aptabase: ${msg}. Tracking will be disabled.`);
     return;
   }

--- a/src/track.ts
+++ b/src/track.ts
@@ -15,6 +15,10 @@ let _client: AptabaseClient | undefined;
 export function init(appKey: string, options?: AptabaseOptions) {
   const [ok, msg] = validate(Platform.OS, appKey, options);
   if (!ok) {
+    if (_client) {
+      _client.stopPolling();
+      _client = undefined;
+    }
     console.warn(`Aptabase: ${msg}. Tracking will be disabled.`);
     return;
   }


### PR DESCRIPTION
Executing init with an empty key string leads to the following warning `Tracking will be disabled.`

However, this tracking is only deactivated if there is no previously initialized tracking object.
Otherwise, the old one will continue to be used, although the warning promises that tracking is now disabled.

Specifically, we use it to deactivate tracking as a user option during the app runtime. The console warning implies that tracking is now also off, but the network logs showed that it was not actually deactivated. Thus, it poses an active risk of violating privacy.

This PR fixes this problem by actually stopping the polling in addition and overwriting the old client with undefined.