### PR TITLE
Add support for checking if the iOS app is running on macOS

### DIFF
--- a/ios/RNAptabaseModule.swift
+++ b/ios/RNAptabaseModule.swift
@@ -2,12 +2,20 @@ import Foundation
 
 @objc(RNAptabaseModule)
 class RNAptabaseModule: NSObject {
+  
   @objc
   func constantsToExport() -> [AnyHashable : Any]! {
     return [
       "appVersion": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as Any,
-      "appBuildNumber": Bundle.main.infoDictionary?["CFBundleVersion"] as Any
-    ]
+      "appBuildNumber": Bundle.main.infoDictionary?["CFBundleVersion"] as Any,
+      "isiOSAppOnMac": {
+        if #available(iOS 14.0, *) {
+          return ProcessInfo.processInfo.isiOSAppOnMac 
+        } else {
+          return false
+        }
+      }()
+      ]
   }
 
   @objc

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,6 +36,10 @@ function getOperatingSystem(): [string, string] {
       return ["Android", Platform.constants.Release];
     case "ios":
       if (Platform.isPad) {
+        if (version.isiOSAppOnMac) {
+          // Version represents the emulated iPadOS version and not the MacOS version
+          return ["MacOS", Platform.Version];
+        }
         return ["iPadOS", Platform.Version];
       }
       return ["iOS", Platform.Version];

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,11 +5,13 @@ const { RNAptabaseModule } = NativeModules;
 type VersionObject = {
   appVersion: string;
   appBuildNumber: string;
+  isiOSAppOnMac: boolean;
 };
 
 const Version: VersionObject = {
   appVersion: RNAptabaseModule?.appVersion?.toString() ?? "",
   appBuildNumber: RNAptabaseModule?.appBuildNumber?.toString() ?? "",
+  isiOSAppOnMac: RNAptabaseModule?.isiOSAppOnMac ?? false,
 };
 
 export default Version;


### PR DESCRIPTION
MacOS makes it possible to run iPad apps on Mac with M chip. This means that React Native still returns Platform iOS and isPad true. For analytics, however, it would be helpful to know the number of MacOS users.
To cover this scenario, I have added the `isiOSAppOnMac` check to the Swift module so that the right operating system is logged.

> `ProcessInfo.processInfo.operatingSystemVersion`: 17.6.0 --> The version of the emulated iPad and not of the Mac


Option 1 could lead to confusion, as MacOS is specified as the operating system.

It would probably be the best to rename the operating system value to "MacOS (designed for iPad)", but the dashboard does currently not show the proper icon. The other option would be to add a note before the version, such as "iPadOS 14.6.0".

I would appreciate feedback and further opinions.